### PR TITLE
Add to the existing CSP policy so we don't spam the console with so many warnings

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -36,7 +36,9 @@ module.exports = function middlewareConstructor(env) {
           ],
           'font-src': [
             "'self'",
-            "https://togetherjs.com"
+            "https://togetherjs.com",
+            "https://fonts.gstatic.com",
+            "https://netdna.bootstrapcdn.com"
           ],
           'img-src': [
             "*"
@@ -67,7 +69,8 @@ module.exports = function middlewareConstructor(env) {
             "https://ajax.googleapis.com",
             "https://fonts.googleapis.com",
             "https://mozorg.cdn.mozilla.net",
-            "https://togetherjs.com"
+            "https://togetherjs.com",
+            "https://netdna.bootstrapcdn.com"
           ]
         }
       });


### PR DESCRIPTION
We're using various fonts and CSS that Thimble wasn't, and this requires a few additions to the CSP setup we're using.  This gets us down to 8 console errors, all of which are about not having a report-uri for violations.  I'll follow up on that in another bug.
