### PR TITLE
Fixes humphd/brackets#108 - Fix Odd Brackets Large Text Issue

### DIFF
--- a/public/friendlycode/js/fc/ui/bramble-proxy.js
+++ b/public/friendlycode/js/fc/ui/bramble-proxy.js
@@ -84,7 +84,6 @@ define(["backbone-events", "fc/prefs"], function(BackboneEvents, Preferences) {
         eventCBs["loaded"].forEach(function(cb) {
           cb();
         });
-        that.executeCommand("_fontSize", { data : prefSize });
         that.executeCommand("_spaceUnits", { data : 2 });
         return;
       }


### PR DESCRIPTION
Fixes https://github.com/humphd/brackets/issues/108.

This patch allows the font size to reset to normal after refresh instead of persisting with the same font size before the refresh.
