### PR TITLE
Fix humphd/brackets#146 - Hook up the reload button in thimble to reload the livedev preview

### DIFF
--- a/public/friendlycode/js/fc/ui/bramble-proxy.js
+++ b/public/friendlycode/js/fc/ui/bramble-proxy.js
@@ -84,6 +84,12 @@ define(["backbone-events", "fc/prefs"], function(BackboneEvents, Preferences) {
         eventCBs["loaded"].forEach(function(cb) {
           cb();
         });
+        
+        // This event is triggered when the reload button is clicked
+        document.querySelector(".reload-button").onclick = function() {
+          that.executeCommand("_reload");
+        };
+
         that.executeCommand("_fontSize", { data : prefSize });
         that.executeCommand("_spaceUnits", { data : 2 });
         return;
@@ -193,6 +199,8 @@ define(["backbone-events", "fc/prefs"], function(BackboneEvents, Preferences) {
       commandCategory = "editorCommand";
       command = "setSpaceUnits";
       params = options.data;
+    } else if (button === "_reload") { 
+      commandCategory = "reloadCommand";
     }
 
     telegraph.postMessage(JSON.stringify({


### PR DESCRIPTION
This PR is part of [this](https://github.com/humphd/brackets-browser-livedev/pull/44) PR to fix https://github.com/humphd/brackets/issues/146
